### PR TITLE
Fix image scaling in documentation

### DIFF
--- a/doc/gettingstarted.md
+++ b/doc/gettingstarted.md
@@ -17,7 +17,6 @@ ZXLive currently requires MacOS 11+, due to older version lacking support for th
 When you open ZXLive for the first time, you will see a window that looks something like this:
 
 ```{figure} _static/mainwindow.png
-:scale: 50 %
 :alt: The ZXLive editor window
 :align: center
 
@@ -26,7 +25,6 @@ The ZXLive editor window
 This is the ***editor mode***. In this mode you can freely edit the diagram. There are three main tools
 
 ```{figure} _static/editor_window_toolbar.png
-:scale: 100 %
 :alt: The toolbar in the Editor window
 :align: center
 
@@ -41,7 +39,6 @@ Let's suppose we want to show that three alternating CNOTs are equivalent to a S
 Start by deleting this graph by either click and dragging a selection rectangle around the graph element, or press `Ctrl-A` to select everything. Then press delete to delete them
 
 ```{figure} _static/deletenodes.gif
-:scale: 50 %
 :alt: Deleting nodes in the Editor window
 :align: center
 
@@ -53,7 +50,6 @@ Now to start the new graph, suppose we want to create the classic circuit of thr
 Select the Z spider vertex type from the vertex selection panel on the right hand side and enter vertex mode by pressing `v`. Then click the locations to place the spiders. Do the same for X spiders and boundary nodes and join them together with wires after pressing `e` to enter edge mode.
 
 ```{figure} _static/create_alternating_cnots.gif
-:scale: 50 %
 :alt: Creating an alternating CNOT circuit
 :align: center
 
@@ -63,7 +59,6 @@ Create a circuit comprised of three alternating CNOTs.
 Now that we have created the three CNOTs, we can try to reduce them to the swap operation. Click "Start Derivation" to begin a new proof using the current ZX diagram.
 
 ```{figure} _static/proof_window.png
-:scale: 50 %
 :alt: The ZXLive Proof window
 :align: center
 
@@ -73,7 +68,6 @@ The ZXLive Proof window.
 We can no longer add or remove nodes or edges in the graph directly. Intstead, we must perform ZX rewrites to reduce the graph to the desired state.
 
 ```{figure} _static/proof_window_toolbar.png
-:scale: 100 %
 :alt: The Proof window's toolbar
 :align: center
 
@@ -83,7 +77,6 @@ The Proof window's toolbar. 1. Select mode (s), 2. Magic wand (w), 3. The type o
 First enter select mode by pressing `s`. Now simply drag and drop one of the Z spiders onto an X spider and ZXLive will automatically perform the bialgebra rule.
 
 ```{figure} _static/bialgebra.gif
-:scale: 50 %
 :alt: The bialgebra rule
 :align: center
 
@@ -95,7 +88,6 @@ Notice that an entry has been added into the rewrite history panel on the right.
 Now drag the adjacent Z and X spiders together to fuse them. Notice that there are some spiders with only two legs and are therefore are equal to the identity. We can remove these by either selecting the spider and clicking the "Basic rules > remove identity" rule in the rule panel on the left, or we could use the magic wand (`w`) and draw the wand over the identity to remove it.
 
 ```{figure} _static/simplify_graph.gif
-:scale: 50 %
 :alt: Merging spiders and removing identities
 :align: center
 
@@ -105,7 +97,6 @@ Simplify the graph by merge spiders of the same type and removing identity spide
 Apply these techniques one more time to reduce the diagram to the SWAP operation. Notice in the animation before that after merging the X spiders, there should be two edges between the resulting Z and X spider --- however they both disappear. This is because ZXLive automatically applied the Hopf algebra rule to eliminate double wires between complementary spiders.
 
 ```{figure} _static/simplify_to_swap.gif
-:scale: 50 %
 :alt: Simplify the graph to a SWAP
 :align: center
 


### PR DESCRIPTION
With the "scaling" attribute, images and gifs are assigned a fixed width and heigh at compile time which is included directly in the html - overwriting the rest of the style sheets which tell it to auto scale.

This caused images to be squished on mobile devices.

Before
<img src="https://github.com/zxcalc/zxlive/assets/44865292/2061c290-a57e-46a0-94f5-44e054852319" width="300">

After 
![Screenshot 2024-06-21 at 10 05 52 AM](https://github.com/zxcalc/zxlive/assets/44865292/4593917f-e3cb-46be-b650-f9d6bdfb8fb3)
