### PR TITLE
create custom selection change signal such that rules are updated only once upon selection

### DIFF
--- a/zxlive/eitem.py
+++ b/zxlive/eitem.py
@@ -144,6 +144,7 @@ class EItem(QGraphicsPathItem):
             self._old_pos = None
         self.is_dragging = False
         self.is_mouse_pressed = False
+        self.graph_scene.selection_changed_custom.emit()
 
 
 

--- a/zxlive/graphscene.py
+++ b/zxlive/graphscene.py
@@ -50,6 +50,8 @@ class GraphScene(QGraphicsScene):
     # Triggers when an edge is dragged. Actual types: EItem, float (old curve_distance), float (new curve_distance)
     edge_dragged = Signal(object, object, object)
 
+    selection_changed_custom = Signal()
+
     def __init__(self) -> None:
         super().__init__()
         self.setSceneRect(0, 0, 2*OFFSET_X, 2*OFFSET_Y)
@@ -74,6 +76,7 @@ class GraphScene(QGraphicsScene):
             if isinstance(it, VItem) and it.v in vs:
                 it.setSelected(True)
                 vs.remove(it.v)
+        self.selection_changed_custom.emit()
 
     def set_graph(self, g: GraphT) -> None:
         """Set the PyZX graph for the scene.
@@ -218,6 +221,7 @@ class GraphScene(QGraphicsScene):
         """Selects all vertices and edges in the scene."""
         for it in self.items():
             it.setSelected(True)
+        self.selection_changed_custom.emit()
 
 
 class EditGraphScene(GraphScene):

--- a/zxlive/graphview.py
+++ b/zxlive/graphview.py
@@ -184,6 +184,7 @@ class GraphView(QGraphicsView):
                     items = [it for it in self.graph_scene.items(self.mapToScene(rect).boundingRect()) if isinstance(it, VItem)]
                     for it in items:
                         it.setSelected(not (len(items) == 1 or e.modifiers() & Qt.KeyboardModifier.ShiftModifier) or not it.isSelected())
+                    self.graph_scene.selection_changed_custom.emit()
             elif self.tool == GraphTool.MagicWand:
                 if self.wand_trace is not None:
                     if not (e.modifiers() & Qt.KeyboardModifier.ShiftModifier):

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -419,7 +419,6 @@ class ProofPanel(BasePanel):
         model = RewriteActionTreeModel.from_dict(action_groups, self)
         self.rewrites_panel.setModel(model)
         self.rewrites_panel.clicked.connect(model.do_rewrite)
-        # TODO: Right now this calls for every single vertex selected, even if we select many at the same time
         self.graph_scene.selection_changed_custom.connect(lambda: model.executor.submit(model.update_on_selection))
 
 

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -420,7 +420,7 @@ class ProofPanel(BasePanel):
         self.rewrites_panel.setModel(model)
         self.rewrites_panel.clicked.connect(model.do_rewrite)
         # TODO: Right now this calls for every single vertex selected, even if we select many at the same time
-        self.graph_scene.selectionChanged.connect(lambda: model.executor.submit(model.update_on_selection))
+        self.graph_scene.selection_changed_custom.connect(lambda: model.executor.submit(model.update_on_selection))
 
 
 class ProofStepItemDelegate(QStyledItemDelegate):


### PR DESCRIPTION
This PR makes the matching and updating the sidebar significantly faster. Previously, if you select n vertices, then it will call the matcher and update the sidebar n times, each time with one more vertex selected. Now we only call it once by creating a custom selection change signal.