### PR TITLE
improvement(typing): Use PySide6 generated stubs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,9 @@ jobs:
         cache: 'pip'
     - name: Install dependecies
       run: |
+        sudo apt-get install -y libegl1
         pip install ".[test]"
-        pyside6-genpyi all
+        pyside6-genpyi QtCore QtGui QtWidgets
     - name: Flake8
       continue-on-error: true
       run:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,8 +23,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
     - name: Install dependecies
-      run:
+      run: |
         pip install ".[test]"
+        pyside6-genpyi all
     - name: Flake8
       continue-on-error: true
       run:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,10 +23,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
     - name: Install dependecies
-      run: |
-        sudo apt-get install -y libegl1
+      run:
         pip install ".[test]"
-        pyside6-genpyi QtCore QtGui QtWidgets
     - name: Flake8
       continue-on-error: true
       run:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,24 @@ To install from source, you need Python >= 3.9 and pip. If you have those, just 
     cd zxlive
     pip install .
 
-Then, you can run ZXLive by typing `python3 -m zxlive`.
+Then, you can run ZXLive by typing `zxlive`.
+
+# Testing
+
+To ensure the quality and correctness of this project, several testing and linting tools are utilized.
+Below are the steps to run the tests and checks:
+
+## 1. Static Type Checks with mypy
+
+You can run mypy to perform static type checking:
+ 
+    mypy zxlive
+
+## 2. Unit Tests with pytest
+
+Execute the test suite using pytest to ensure all tests pass:
+
+    pytest
 
 # Documentation
 
@@ -19,6 +36,5 @@ This project uses Sphinx to build a ReadTheDocs page. In addition, it uses the M
 
 The documentation can be built with
 
-```
-cd doc; make html
-```
+    cd doc
+    make html

--- a/README.md
+++ b/README.md
@@ -11,7 +11,28 @@ To install from source, you need Python >= 3.9 and pip. If you have those, just 
     cd zxlive
     pip install .
 
-Then, you can run ZXLive by typing `python3 -m zxlive`.
+Then, you can run ZXLive by typing `zxlive`.
+
+# Testing
+
+To ensure the quality and correctness of this project, several testing and linting tools are utilized.
+Below are the steps to run the tests and checks:
+
+## 1. Static Type Checks with mypy
+
+Before running mypy, generate the required type stubs for PySide6:
+
+    pyside6-genpyi all
+
+After generating the type stubs, you can run mypy to perform static type checking:
+ 
+    mypy zxlive
+
+## 2. Unit Tests with pytest
+
+Execute the test suite using pytest to ensure all tests pass:
+
+    pytest
 
 # Documentation
 
@@ -19,6 +40,5 @@ This project uses Sphinx to build a ReadTheDocs page. In addition, it uses the M
 
 The documentation can be built with
 
-```
-cd doc; make html
-```
+    cd doc
+    make html

--- a/README.md
+++ b/README.md
@@ -11,28 +11,7 @@ To install from source, you need Python >= 3.9 and pip. If you have those, just 
     cd zxlive
     pip install .
 
-Then, you can run ZXLive by typing `zxlive`.
-
-# Testing
-
-To ensure the quality and correctness of this project, several testing and linting tools are utilized.
-Below are the steps to run the tests and checks:
-
-## 1. Static Type Checks with mypy
-
-Before running mypy, generate the required type stubs for PySide6:
-
-    pyside6-genpyi all
-
-After generating the type stubs, you can run mypy to perform static type checking:
- 
-    mypy zxlive
-
-## 2. Unit Tests with pytest
-
-Execute the test suite using pytest to ensure all tests pass:
-
-    pytest
+Then, you can run ZXLive by typing `python3 -m zxlive`.
 
 # Documentation
 
@@ -40,5 +19,6 @@ This project uses Sphinx to build a ReadTheDocs page. In addition, it uses the M
 
 The documentation can be built with
 
-    cd doc
-    make html
+```
+cd doc; make html
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: Scientific/Engineering"
 ]
 dependencies = [
-    "PySide6",
+    "PySide6 >= 6.7.2",
     "pyzx @ git+https://github.com/Quantomatic/pyzx.git",
     "networkx",
     "numpy",
@@ -38,7 +38,6 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "PySide6-stubs",
     "mypy",
     "pyproject-flake8",
     "pylint",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ pyzx>=0.8.0
 networkx~=3.1
 numpy~=1.25.2
 pytest-qt~=4.2.0
-PySide6~=6.5.2
-PySide6-stubs
+PySide6~=6.7.2,
 shapely~=2.0.1
 shapely-stubs @ git+https://github.com/ciscorn/shapely-stubs.git
 pyperclip>=1.8.1


### PR DESCRIPTION
Since PySide6>=6.7 includes stub files, we can drop the PySide6-stubs dependency.