### PR TITLE
Detect inputs and outputs before saving as JSON

### DIFF
--- a/zxlive/dialogs.py
+++ b/zxlive/dialogs.py
@@ -210,6 +210,10 @@ def save_diagram_dialog(graph: GraphT, parent: QWidget) -> Optional[tuple[str, F
     file_path, selected_format = file_path_and_format
 
     if selected_format in (FileFormat.QGraph, FileFormat.Json):
+        try:
+            graph.auto_detect_io()
+        except TypeError:
+            pass
         data = graph.to_json()
     elif selected_format == FileFormat.QASM:
         try:


### PR DESCRIPTION
JSON explicitly stores the inputs and outputs and their order (I'm not sure about the other formats). Having this information available in the saved file is useful for reading the JSON with other programs.