### PR TITLE
Fix pivot basic rewrite with new PyZX version

### DIFF
--- a/zxlive/custom_rule.py
+++ b/zxlive/custom_rule.py
@@ -271,11 +271,8 @@ def filter_matchings_if_symbolic_compatible(matchings: list[Dict[VT, VT]], left:
     for matching in matchings:
         if len(matching) != len(left):
             continue
-        try:
-            match_symbolic_parameters(matching, left, right)
-            new_matchings.append(matching)
-        except ValueError:
-            pass
+        match_symbolic_parameters(matching, left, right)
+        new_matchings.append(matching)
     return new_matchings
 
 

--- a/zxlive/dialogs.py
+++ b/zxlive/dialogs.py
@@ -228,10 +228,7 @@ def save_diagram_dialog(graph: GraphT, parent: QWidget) -> Optional[tuple[str, F
     file_path, selected_format = file_path_and_format
 
     if selected_format in (FileFormat.QGraph, FileFormat.Json):
-        try:
-            graph.auto_detect_io()
-        except TypeError:
-            pass
+        graph.auto_detect_io()
         data = graph.to_json()
     elif selected_format == FileFormat.QASM:
         try:

--- a/zxlive/rewrite_action.py
+++ b/zxlive/rewrite_action.py
@@ -79,6 +79,8 @@ class RewriteAction:
 
         try:
             g, rem_verts = self.apply_rewrite(g, matches)
+        except ValueError as ex:
+            raise ex
         except Exception as ex:
             show_error_msg('Error while applying rewrite rule', str(ex))
             return

--- a/zxlive/rule_panel.py
+++ b/zxlive/rule_panel.py
@@ -97,12 +97,9 @@ class RulePanel(EditorBasePanel):
         self.update_io_labels(self.graph_scene)
 
     def update_io_labels(self, scene: EditGraphScene) -> None:
-        try:
-            scene.g.auto_detect_io()
-            for v in scene.g.vertices():
-                if v in scene.g.inputs():
-                    scene.vertex_map[v].phase_item.setPlainText("in-" + str(scene.g.inputs().index(v)))
-                elif v in scene.g.outputs():
-                    scene.vertex_map[v].phase_item.setPlainText("out-" + str(scene.g.outputs().index(v)))
-        except TypeError:
-            return
+        scene.g.auto_detect_io()
+        for v in scene.g.vertices():
+            if v in scene.g.inputs():
+                scene.vertex_map[v].phase_item.setPlainText("in-" + str(scene.g.inputs().index(v)))
+            elif v in scene.g.outputs():
+                scene.vertex_map[v].phase_item.setPlainText("out-" + str(scene.g.outputs().index(v)))

--- a/zxlive/vitem.py
+++ b/zxlive/vitem.py
@@ -107,6 +107,7 @@ class VItem(QGraphicsPathItem):
 
     @property
     def ty(self) -> VertexType:
+        # https://github.com/zxcalc/zxlive/pull/281
         _ty: VertexType = self.g.type(self.v)
         return _ty
 


### PR DESCRIPTION
This draft uncovers the issue with pivoting which I will solve next. cc @RazinShaikh. #256 

```
Traceback (most recent call last):
  File "/home/mcoll/repos/github.com/colltoaction/zxlive/zxlive/rewrite_action.py", line 281, in do_rewrite
    node.rewrite_action.do_rewrite(self.proof_panel)
  File "/home/mcoll/repos/github.com/colltoaction/zxlive/zxlive/rewrite_action.py", line 114, in do_rewrite
    g, rem_verts = self.apply_rewrite(g, matches)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mcoll/repos/github.com/colltoaction/zxlive/zxlive/rewrite_action.py", line 129, in apply_rewrite
    etab, rem_verts, rem_edges, check_isolated_vertices = self.rule(g, matches)
                                                          ^^^^^^^^^^^^^^^^^^^^^
  File "/home/mcoll/repos/github.com/colltoaction/zxlive/zxlive/rewrite_data.py", line 117, in rule
    simplification(g)
  File "/home/mcoll/.local/lib/python3.11/site-packages/pyzx/simplify.py", line 109, in pivot_simp
    return simp(g, 'pivot_simp', match_pivot_parallel, pivot, matchf=matchf, quiet=quiet, stats=stats)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mcoll/.local/lib/python3.11/site-packages/pyzx/simplify.py", line 98, in simp
    g.remove_edges(rem_edges)
  File "/home/mcoll/.local/lib/python3.11/site-packages/pyzx/graph/multigraph.py", line 237, in remove_edges
    self.remove_edge(e)
  File "/home/mcoll/.local/lib/python3.11/site-packages/pyzx/graph/multigraph.py", line 240, in remove_edge
    s,t,ty = edge
    ^^^^^^
ValueError: not enough values to unpack (expected 3, got 2)
```