### PR TITLE
Move "refresh rules" in a context menu

### DIFF
--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -94,7 +94,7 @@ class ProofPanel(BasePanel):
 
     def init_rewrites_bar(self) -> None:
         self.reset_rewrite_panel_style()
-        self._refresh_rewrites_model()
+        self.rewrites_panel.refresh_rewrites_model()
 
     def reset_rewrite_panel_style(self) -> None:
         self.rewrites_panel.setUniformRowHeights(True)
@@ -425,11 +425,3 @@ class ProofPanel(BasePanel):
         basicrules.color_change(new_g, v)
         cmd = AddRewriteStep(self.graph_view, new_g, self.step_view, "color change")
         self.undo_stack.push(cmd)
-
-    def _refresh_rewrites_model(self) -> None:
-        refresh_custom_rules()
-        model = RewriteActionTreeModel.from_dict(action_groups, self)
-        self.rewrites_panel.setModel(model)
-        self.rewrites_panel.expand(model.index(0,0))
-        self.rewrites_panel.clicked.connect(model.do_rewrite)
-        self.graph_scene.selection_changed_custom.connect(lambda: model.executor.submit(model.update_on_selection))

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -23,7 +23,7 @@ from .eitem import EItem
 from .graphscene import GraphScene
 from .graphview import GraphTool, ProofGraphView, WandTrace
 from .proof import ProofModel, ProofStepView
-from .rewrite_action import RewriteActionTreeModel
+from .rewrite_action import RewriteActionTreeModel, RewriteActionTreeView
 from .rewrite_data import action_groups, refresh_custom_rules
 from .settings import display_setting
 from .sfx import SFXEnum
@@ -43,7 +43,7 @@ class ProofPanel(BasePanel):
         self.splitter.addWidget(self.graph_view)
         self.graph_view.set_graph(graph)
 
-        self.rewrites_panel = QTreeView(self)
+        self.rewrites_panel = RewriteActionTreeView(self)
         self.splitter.insertWidget(0, self.rewrites_panel)
         self.init_rewrites_bar()
 

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -5,7 +5,7 @@ from typing import Iterator, Union, cast
 
 import pyzx
 from PySide6.QtCore import QPointF, QSize
-from PySide6.QtGui import QAction, QFontInfo, QIcon, QVector2D
+from PySide6.QtGui import QAction, QIcon, QVector2D
 from PySide6.QtWidgets import QInputDialog, QToolButton
 from pyzx import VertexType, basicrules
 from pyzx.graph.jsonparser import string_to_phase
@@ -22,8 +22,7 @@ from .eitem import EItem
 from .graphscene import GraphScene
 from .graphview import GraphTool, ProofGraphView, WandTrace
 from .proof import ProofModel, ProofStepView
-from .rewrite_action import RewriteActionTreeModel, RewriteActionTreeView
-from .rewrite_data import action_groups, refresh_custom_rules
+from .rewrite_action import RewriteActionTreeView
 from .settings import display_setting
 from .sfx import SFXEnum
 from .vitem import SCALE, W_INPUT_OFFSET, DragState, VItem

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -6,8 +6,7 @@ from typing import Iterator, Union, cast
 import pyzx
 from PySide6.QtCore import QPointF, QSize
 from PySide6.QtGui import QAction, QFontInfo, QIcon, QVector2D
-from PySide6.QtWidgets import (QAbstractItemView, QInputDialog, QToolButton,
-                               QTreeView)
+from PySide6.QtWidgets import QInputDialog, QToolButton
 from pyzx import VertexType, basicrules
 from pyzx.graph.jsonparser import string_to_phase
 from pyzx.utils import (EdgeType, FractionLike, get_w_partner, get_z_box_label,
@@ -45,7 +44,6 @@ class ProofPanel(BasePanel):
 
         self.rewrites_panel = RewriteActionTreeView(self)
         self.splitter.insertWidget(0, self.rewrites_panel)
-        self.init_rewrites_bar()
 
         self.graph_view.wand_trace_finished.connect(self._wand_trace_finished)
         self.graph_scene.vertex_dragged.connect(self._vertex_dragged)
@@ -92,29 +90,9 @@ class ProofPanel(BasePanel):
         yield ToolbarSection(*self.identity_choice, exclusive=True)
         yield ToolbarSection(*self.actions())
 
-    def init_rewrites_bar(self) -> None:
-        self.reset_rewrite_panel_style()
-        self.rewrites_panel.refresh_rewrites_model()
-
-    def reset_rewrite_panel_style(self) -> None:
-        self.rewrites_panel.setUniformRowHeights(True)
-        self.rewrites_panel.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
-        self.rewrites_panel.setStyleSheet(
-            f'''
-            QTreeView::Item:hover {{
-                background-color: #e2f4ff;
-            }}
-            QTreeView::Item{{
-                height:{display_setting.font.pointSizeF() * 2.5}px;
-            }}
-            QTreeView::Item:!enabled {{
-                color: #c0c0c0;
-            }}
-            ''')
-
     def update_font(self) -> None:
         self.rewrites_panel.setFont(display_setting.font)
-        self.reset_rewrite_panel_style()
+        self.rewrites_panel.reset_rewrite_panel_style()
         super().update_font()
 
     def parse_selection(self) -> tuple[list[VT], list[ET]]:

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -89,13 +89,8 @@ class ProofPanel(BasePanel):
         self.identity_choice[1].setText("X")
         self.identity_choice[1].setCheckable(True)
 
-        self.refresh_rules = QToolButton(self)
-        self.refresh_rules.setText("Refresh rules")
-        self.refresh_rules.clicked.connect(self._refresh_rewrites_model)
-
         yield ToolbarSection(*self.identity_choice, exclusive=True)
         yield ToolbarSection(*self.actions())
-        yield ToolbarSection(self.refresh_rules)
 
     def init_rewrites_bar(self) -> None:
         self.reset_rewrite_panel_style()

--- a/zxlive/rewrite_action.py
+++ b/zxlive/rewrite_action.py
@@ -10,7 +10,7 @@ import pyzx
 from PySide6.QtCore import (Qt, QAbstractItemModel, QModelIndex, QPersistentModelIndex,
                             Signal, QObject, QMetaObject, QIODevice, QBuffer, QPoint, QPointF, QLineF)
 from PySide6.QtGui import QPixmap, QColor, QPen
-from PySide6.QtWidgets import QMenu, QTreeView
+from PySide6.QtWidgets import QAbstractItemView, QMenu, QTreeView
 
 
 from .animations import make_animation
@@ -313,15 +313,33 @@ class RewriteActionTreeView(QTreeView):
         self.proof_panel = parent
         self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         self.customContextMenuRequested.connect(self.show_context_menu)
+        self.reset_rewrite_panel_style()
+        self.refresh_rewrites_model()
+
+    def reset_rewrite_panel_style(self) -> None:
+        self.setUniformRowHeights(True)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
+        self.setStyleSheet(
+            f'''
+            QTreeView::Item:hover {{
+                background-color: #e2f4ff;
+            }}
+            QTreeView::Item{{
+                height:{display_setting.font.pointSizeF() * 2.5}px;
+            }}
+            QTreeView::Item:!enabled {{
+                color: #c0c0c0;
+            }}
+            ''')
 
     def show_context_menu(self, position: QPoint) -> None:
         context_menu = QMenu(self)
         refresh_rules = context_menu.addAction("Refresh rules")
         action = context_menu.exec_(self.mapToGlobal(position))
         if action == refresh_rules:
-            self._refresh_rewrites_model()
+            self.refresh_rewrites_model()
 
-    def _refresh_rewrites_model(self) -> None:
+    def refresh_rewrites_model(self) -> None:
         refresh_custom_rules()
         model = RewriteActionTreeModel.from_dict(action_groups, self.proof_panel)
         self.setModel(model)

--- a/zxlive/rewrite_action.py
+++ b/zxlive/rewrite_action.py
@@ -10,13 +10,14 @@ import pyzx
 from PySide6.QtCore import (Qt, QAbstractItemModel, QModelIndex, QPersistentModelIndex,
                             Signal, QObject, QMetaObject, QIODevice, QBuffer, QPoint, QPointF, QLineF)
 from PySide6.QtGui import QPixmap, QColor, QPen
+from PySide6.QtWidgets import QMenu, QTreeView
 
 
 from .animations import make_animation
 from .commands import AddRewriteStep
 from .common import ET, GraphT, VT, get_data
 from .dialogs import show_error_msg
-from .rewrite_data import is_rewrite_data, RewriteData, MatchType, MATCHES_VERTICES
+from .rewrite_data import is_rewrite_data, RewriteData, MatchType, MATCHES_VERTICES, refresh_custom_rules, action_groups
 from .settings import display_setting
 from .graphscene import GraphScene
 from .graphview import GraphView
@@ -305,3 +306,25 @@ class RewriteActionTreeModel(QAbstractItemModel):
         g = self.proof_panel.graph_scene.g
         self.root_item.update_on_selection(g, selection, edges)
         QMetaObject.invokeMethod(self.emitter, "finished", Qt.ConnectionType.QueuedConnection)  # type: ignore
+
+class RewriteActionTreeView(QTreeView):
+    def __init__(self, parent: 'ProofPanel'):
+        super().__init__(parent)
+        self.proof_panel = parent
+        self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.customContextMenuRequested.connect(self.show_context_menu)
+
+    def show_context_menu(self, position: QPoint) -> None:
+        context_menu = QMenu(self)
+        refresh_rules = context_menu.addAction("Refresh rules")
+        action = context_menu.exec_(self.mapToGlobal(position))
+        if action == refresh_rules:
+            self._refresh_rewrites_model()
+
+    def _refresh_rewrites_model(self) -> None:
+        refresh_custom_rules()
+        model = RewriteActionTreeModel.from_dict(action_groups, self.proof_panel)
+        self.setModel(model)
+        self.expand(model.index(0,0))
+        self.clicked.connect(model.do_rewrite)
+        self.proof_panel.graph_scene.selection_changed_custom.connect(lambda: model.executor.submit(model.update_on_selection))


### PR DESCRIPTION
Removed the refresh rules button and added a context menu on right click to perform that action