### PR TITLE
Fix bug which generates same type of error also mentioned in #310.

### DIFF
--- a/zxlive/graphscene.py
+++ b/zxlive/graphscene.py
@@ -117,6 +117,7 @@ class GraphScene(QGraphicsScene):
                 anim_v.stop()
             selected_vertices.discard(v)
             self.removeItem(v_item)
+            del self.vertex_map[v]
 
         for e in diff.removed_edges:
             edge_idx = len(self.edge_map[e]) - 1
@@ -129,6 +130,8 @@ class GraphScene(QGraphicsScene):
             self.edge_map[e].pop(edge_idx)
             s, t = self.g.edge_st(e)
             self.update_edge_curves(s, t)
+            if len(self.edge_map[e]) == 0:
+                del self.edge_map[e]
 
         new_g = diff.apply_diff(self.g)
         # Mypy issue: https://github.com/python/mypy/issues/11673

--- a/zxlive/vitem.py
+++ b/zxlive/vitem.py
@@ -110,6 +110,7 @@ class VItem(QGraphicsPathItem):
         _ty: VertexType = self.g.type(self.v)
         return _ty
 
+
     @property
     def is_dragging(self) -> bool:
         return self._old_pos is not None
@@ -424,7 +425,7 @@ class PhaseItem(QGraphicsTextItem):
 
     def refresh(self) -> None:
         """Call this when a vertex moves or its phase changes"""
-        vertex_type = self.v_item.g.type(self.v_item.v)
+        vertex_type = self.v_item.ty
         if vertex_type == VertexType.Z_BOX:
             self.setPlainText(str(get_z_box_label(self.v_item.g, self.v_item.v)))
         elif vertex_type != VertexType.BOUNDARY:


### PR DESCRIPTION
There was a bug where if you made some vertices, and then deleted them, that the corresponding VItems were still stored in the vertex_map of the GraphScene. This correctly deletes them, preventing weird behaviour.