### PR TITLE
Magic drag and drop understands H-boxes

### DIFF
--- a/zxlive/eitem.py
+++ b/zxlive/eitem.py
@@ -161,6 +161,15 @@ class EItem(QGraphicsPathItem):
         self.is_mouse_pressed = False
         self.graph_scene.selection_changed_custom.emit()
 
+    def mouseDoubleClickEvent(self, e: QGraphicsSceneMouseEvent) -> None:
+        super().mouseDoubleClickEvent(e)
+        if self.is_animated:
+            e.ignore()
+            return
+        scene = self.scene()
+        if TYPE_CHECKING: assert isinstance(scene, GraphScene)
+        scene.edge_double_clicked.emit(self.e)
+
 
 
 # TODO: This is essentially a clone of EItem. We should common it up!

--- a/zxlive/graphscene.py
+++ b/zxlive/graphscene.py
@@ -52,6 +52,7 @@ class GraphScene(QGraphicsScene):
 
     # Triggers when an edge is dragged. Actual types: EItem, float (old curve_distance), float (new curve_distance)
     edge_dragged = Signal(object, object, object)
+    edge_double_clicked = Signal(object)  # Actual type: ET
 
     selection_changed_custom = Signal()
 

--- a/zxlive/graphview.py
+++ b/zxlive/graphview.py
@@ -150,6 +150,7 @@ class GraphView(QGraphicsView):
             e.ignore()
 
     def keyPressEvent(self, e: QKeyEvent) -> None:
+        """Logic for moving selected vertices with arrow keys"""
         if Qt.KeyboardModifier.ControlModifier & e.modifiers():
             g = self.graph_scene.g
             if Qt.KeyboardModifier.ShiftModifier & e.modifiers():

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -38,6 +38,7 @@ class ProofPanel(BasePanel):
         self.graph_scene = GraphScene()
         self.graph_scene.vertices_moved.connect(self._vert_moved)
         self.graph_scene.vertex_double_clicked.connect(self._vert_double_clicked)
+        self.graph_scene.edge_double_clicked.connect(self._edge_double_clicked)
 
         self.graph_view = ProofGraphView(self.graph_scene)
         self.splitter.addWidget(self.graph_view)
@@ -422,3 +423,11 @@ class ProofPanel(BasePanel):
             cmd = AddRewriteStep(self.graph_view, new_g, self.step_view, "Turn Hadamard into edge")
             self.undo_stack.push(cmd)
             return
+
+    def _edge_double_clicked(self, e: VT) -> None:
+        """When an edge is double clicked, we change it to an H-box if it is a Hadamard edge."""
+        new_g = copy.deepcopy(self.graph)
+        if new_g.edge_type(e) == EdgeType.HADAMARD:
+            pyzx.hrules.had_edge_to_hbox(new_g, e)
+            cmd = AddRewriteStep(self.graph_view, new_g, self.step_view, "Turn edge into Hadamard")
+            self.undo_stack.push(cmd)

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -435,7 +435,7 @@ class ProofPanel(BasePanel):
             self.undo_stack.push(cmd)
             return
 
-    def _edge_double_clicked(self, e: VT) -> None:
+    def _edge_double_clicked(self, e: ET) -> None:
         """When an edge is double clicked, we change it to an H-box if it is a Hadamard edge."""
         new_g = copy.deepcopy(self.graph)
         if new_g.edge_type(e) == EdgeType.HADAMARD:


### PR DESCRIPTION
This makes some of the convienence features for rewriting Z- and X-spiders available to H-boxes.
In particular:
* double clicking a Hadamard edge turns it into an H-box, and vice versa.
* The magic drag and drop now also works for some actions involving H-boxes. In particular, dragging an X(0) onto an H-box 'explodes' it, A X(pi) gets fused into it, a Z(pi) also 'explodes' it (i.e. copies through).
* 
I think I also want to implement that you can drag a Z- or X-spider onto a H-box representing a Hadamard in order to do color change.

See also #162 . This PR requires some new pushes onto the PyZX repo.