### PR TITLE
Fix ZXLive not loading graphs as Multigraphs with auto simplify disabled

### DIFF
--- a/zxlive/custom_rule.py
+++ b/zxlive/custom_rule.py
@@ -184,6 +184,8 @@ class CustomRule:
         rhs_graph = GraphT.from_json(d['rhs_graph'])
         # Mypy issue: https://github.com/python/mypy/issues/11673
         assert (isinstance(lhs_graph, GraphT) and isinstance(rhs_graph, GraphT))  # type: ignore
+        lhs_graph.set_auto_simplify(False)
+        rhs_graph.set_auto_simplify(False)
         return cls(lhs_graph, rhs_graph, d['name'], d['description'])
 
     def to_rewrite_data(self) -> "RewriteData":

--- a/zxlive/dialogs.py
+++ b/zxlive/dialogs.py
@@ -140,15 +140,18 @@ def import_diagram_from_file(file_path: str, selected_filter: str = FileFormat.A
             return ImportRuleOutput(selected_format, file_path, CustomRule.from_json(data))
         elif selected_format in (FileFormat.QGraph, FileFormat.Json):
             g = GraphT.from_json(data)
+            if TYPE_CHECKING: assert isinstance(g, GraphT)
             g.set_auto_simplify(False)
             return ImportGraphOutput(selected_format, file_path, g)  # type: ignore # This is something that needs to be better annotated in PyZX
         elif selected_format == FileFormat.QASM:
             g = Circuit.from_qasm(data).to_graph(zh=True,backend='multigraph')
+            if TYPE_CHECKING: assert isinstance(g, GraphT)
             g.set_auto_simplify(False)
             return ImportGraphOutput(selected_format, file_path, ) # type: ignore
         elif selected_format == FileFormat.TikZ:
             try:
                 g = GraphT.from_tikz(data)
+                if TYPE_CHECKING: assert isinstance(g, GraphT)
                 g.set_auto_simplify(False)
                 return ImportGraphOutput(selected_format, file_path, g)  # type: ignore
             except ValueError:
@@ -157,16 +160,19 @@ def import_diagram_from_file(file_path: str, selected_filter: str = FileFormat.A
             assert selected_format == FileFormat.All
             try:
                 g = Circuit.load(file_path).to_graph(zx=True,backend='multigraph')
+                if TYPE_CHECKING: assert isinstance(g, GraphT)
                 g.set_auto_simplify(False)
                 return ImportGraphOutput(FileFormat.QASM, file_path, g)  # type: ignore
             except TypeError:
                 try:
                     g = GraphT.from_json(data)
+                    if TYPE_CHECKING: assert isinstance(g, GraphT)
                     g.set_auto_simplify(False)
                     return ImportGraphOutput(FileFormat.QGraph, file_path, g)  # type: ignore
                 except Exception:
                     try:
                         g = GraphT.from_tikz(data)
+                        if TYPE_CHECKING: assert isinstance(g, GraphT)
                         g.set_auto_simplify(False)
                         return ImportGraphOutput(FileFormat.TikZ, file_path, g)  # type: ignore
                     except:

--- a/zxlive/dialogs.py
+++ b/zxlive/dialogs.py
@@ -139,25 +139,36 @@ def import_diagram_from_file(file_path: str, selected_filter: str = FileFormat.A
         elif selected_format == FileFormat.ZXRule:
             return ImportRuleOutput(selected_format, file_path, CustomRule.from_json(data))
         elif selected_format in (FileFormat.QGraph, FileFormat.Json):
-            return ImportGraphOutput(selected_format, file_path, GraphT.from_json(data))  # type: ignore # This is something that needs to be better annotated in PyZX
+            g = GraphT.from_json(data)
+            g.set_auto_simplify(False)
+            return ImportGraphOutput(selected_format, file_path, g)  # type: ignore # This is something that needs to be better annotated in PyZX
         elif selected_format == FileFormat.QASM:
-            return ImportGraphOutput(selected_format, file_path, Circuit.from_qasm(data).to_graph()) # type: ignore
+            g = Circuit.from_qasm(data).to_graph(zh=True,backend='multigraph')
+            g.set_auto_simplify(False)
+            return ImportGraphOutput(selected_format, file_path, ) # type: ignore
         elif selected_format == FileFormat.TikZ:
             try:
-                return ImportGraphOutput(selected_format, file_path, GraphT.from_tikz(data))  # type: ignore
+                g = GraphT.from_tikz(data)
+                g.set_auto_simplify(False)
+                return ImportGraphOutput(selected_format, file_path, g)  # type: ignore
             except ValueError:
                 raise ValueError("Probable reason: attempted to import a proof from TikZ, which is not supported.")
         else:
             assert selected_format == FileFormat.All
             try:
-                circ = Circuit.load(file_path)
-                return ImportGraphOutput(FileFormat.QASM, file_path, circ.to_graph())  # type: ignore
+                g = Circuit.load(file_path).to_graph(zx=True,backend='multigraph')
+                g.set_auto_simplify(False)
+                return ImportGraphOutput(FileFormat.QASM, file_path, g)  # type: ignore
             except TypeError:
                 try:
-                    return ImportGraphOutput(FileFormat.QGraph, file_path, GraphT.from_json(data))  # type: ignore
+                    g = GraphT.from_json(data)
+                    g.set_auto_simplify(False)
+                    return ImportGraphOutput(FileFormat.QGraph, file_path, g)  # type: ignore
                 except Exception:
                     try:
-                        return ImportGraphOutput(FileFormat.TikZ, file_path, GraphT.from_tikz(data))  # type: ignore
+                        g = GraphT.from_tikz(data)
+                        g.set_auto_simplify(False)
+                        return ImportGraphOutput(FileFormat.TikZ, file_path, g)  # type: ignore
                     except:
                         show_error_msg(f"Failed to import {selected_format.name} file",
                                        f"Couldn't determine filetype: {file_path}.", parent=parent)

--- a/zxlive/dialogs.py
+++ b/zxlive/dialogs.py
@@ -159,7 +159,7 @@ def import_diagram_from_file(file_path: str, selected_filter: str = FileFormat.A
         else:
             assert selected_format == FileFormat.All
             try:
-                g = Circuit.load(file_path).to_graph(zx=True,backend='multigraph')
+                g = Circuit.load(file_path).to_graph(zh=True,backend='multigraph')
                 if TYPE_CHECKING: assert isinstance(g, GraphT)
                 g.set_auto_simplify(False)
                 return ImportGraphOutput(FileFormat.QASM, file_path, g)  # type: ignore

--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -182,6 +182,7 @@ class EditorBasePanel(BasePanel):
 
     def add_edge(self, u: VT, v: VT, verts: list[VItem]) -> None:
         """Add an edge between vertices u and v. `verts` is a list of VItems that collide with the edge.
+        If self.snap_vertex_edge is true, then we try to connect `u` through all the `vertices` in `verts`, and then to `v`.
         """
         cmd: BaseCommand
         graph = self.graph_view.graph_scene.g

--- a/zxlive/proof.py
+++ b/zxlive/proof.py
@@ -47,6 +47,7 @@ class Rewrite(NamedTuple):
         grouped_rewrites = d.get("grouped_rewrites")
         graph = GraphT.from_json(d["graph"])
         assert isinstance(graph, GraphT)
+        graph.set_auto_simplify(False)
 
         return Rewrite(
             display_name=d.get("display_name", d["rule"]), # Old proofs may not have display names
@@ -213,7 +214,8 @@ class ProofModel(QAbstractListModel):
             d = json_str
         initial_graph = GraphT.from_json(d["initial_graph"])
         # Mypy issue: https://github.com/python/mypy/issues/11673
-        assert isinstance(initial_graph, GraphT)  # type: ignore
+        if TYPE_CHECKING: assert isinstance(initial_graph, GraphT)
+        initial_graph.set_auto_simplify(False)
         model = ProofModel(initial_graph)
         for step in d["proof_steps"]:
             rewrite = Rewrite.from_json(step)


### PR DESCRIPTION
When you load a graph, it was sometimes loaded as a GraphS instead of a Multigraph, and in all cases set_auto_simplify was not set properly leading to unexpected behaviour when adding edges (and exceptions).