### PR TITLE
Add matrix precision control and clipboard copy to matrix dialog

### DIFF
--- a/zxlive/settings.py
+++ b/zxlive/settings.py
@@ -37,6 +37,7 @@ general_defaults: dict[str, str | QTabWidget.TabPosition | int] = {
     "previews-show": True,
     "sparkle-mode": True,
     'sound-effects': False,
+    "matrix/precision": 4,
 }
 
 font_defaults: dict[str, str | int | None] = {

--- a/zxlive/settings_dialog.py
+++ b/zxlive/settings_dialog.py
@@ -81,6 +81,7 @@ general_settings: list[SettingsData] = [
     {"id": "previews-show", "label": "Show rewrite previews","type": FormInputType.Bool},
     {"id": "sparkle-mode", "label": "Sparkle Mode", "type": FormInputType.Bool},
     {"id": "sound-effects", "label": "Sound Effects", "type": FormInputType.Bool},
+    {"id": "matrix/precision", "label": "Matrix display precision", "type": FormInputType.Int},
 ]
 
 


### PR DESCRIPTION
 Fixes #316 

- Add 'Matrix display precision' to settings dialog
- Use setting as default in matrix view
- Add precision spinbox and 'Copy to Clipboard' button to matrix dialog
- Refactor for mypy and code clarity