### PR TITLE
Support for blank nodes to add decorations including text and edges

### DIFF
--- a/zxlive/base_panel.py
+++ b/zxlive/base_panel.py
@@ -123,6 +123,9 @@ class BasePanel(QWidget):
     def paste_selection(self, graph: GraphT) -> None:
         pass
 
+    def paste_graph(self, graph: GraphT) -> None:
+        pass
+
     def update_colors(self) -> None:
         self.graph_scene.update_colors()
 

--- a/zxlive/base_panel.py
+++ b/zxlive/base_panel.py
@@ -117,6 +117,12 @@ class BasePanel(QWidget):
         assert isinstance(copied_graph, GraphT)  # type: ignore
         return copied_graph
 
+    def delete_selection(self) -> None:
+        pass
+
+    def paste_selection(self, graph: GraphT) -> None:
+        pass
+
     def update_colors(self) -> None:
         self.graph_scene.update_colors()
 

--- a/zxlive/commands.py
+++ b/zxlive/commands.py
@@ -97,6 +97,12 @@ class SetGraph(BaseCommand):
         self.old_g = self.graph_view.graph_scene.g
         self.graph_view.set_graph(self.new_g)
 
+@dataclass
+class SetGraphProofMode(SetGraph, ProofModeMixin):
+    step_view: ProofStepView
+    def __init__(self, graph_view: GraphView, new_g: GraphT, step_view: ProofStepView) -> None:
+        SetGraph.__init__(self, graph_view, new_g)
+        self.setup_proof_mode(step_view)
 
 @dataclass
 class UpdateGraph(BaseCommand):
@@ -119,6 +125,12 @@ class UpdateGraph(BaseCommand):
         self.g = self.new_g
         self.update_graph_view(True)
 
+@dataclass
+class UpdateGraphProofMode(UpdateGraph, ProofModeMixin):
+    step_view: ProofStepView
+    def __init__(self, graph_view: GraphView, new_g: GraphT, step_view: ProofStepView) -> None:
+        UpdateGraph.__init__(self, graph_view, new_g)
+        self.setup_proof_mode(step_view)
 
 @dataclass
 class ChangeNodeType(BaseCommand):

--- a/zxlive/commands.py
+++ b/zxlive/commands.py
@@ -4,7 +4,7 @@ import copy
 from collections import namedtuple
 from dataclasses import dataclass, field
 from fractions import Fraction
-from typing import Any, Callable, Iterable, Optional, Set, Type, Union
+from typing import Callable, Iterable, Optional, Set, Union
 
 from PySide6.QtCore import QModelIndex
 from PySide6.QtGui import QUndoCommand
@@ -72,12 +72,12 @@ class ProofModeCommand(QUndoCommand):
     def undo(self) -> None:
         self.step_view.move_to_step(self.proof_step_index)
         self.command.undo()
-        self.step_view.model().set_graph(self.proof_step_index, self.command.graph_view.graph_scene.g)
+        self.step_view.model().set_graph(self.proof_step_index, self.command.g)
 
     def redo(self) -> None:
         self.step_view.move_to_step(self.proof_step_index)
         self.command.redo()
-        self.step_view.model().set_graph(self.proof_step_index, self.command.graph_view.graph_scene.g)
+        self.step_view.model().set_graph(self.proof_step_index, self.command.g)
 
 
 @dataclass

--- a/zxlive/commands.py
+++ b/zxlive/commands.py
@@ -208,6 +208,26 @@ class AddNode(BaseCommand):
         self._added_vert = self.g.add_vertex(self.vty, y,x)
         self.update_graph_view()
 
+
+@dataclass
+class AddNodeProofMode(AddNode):
+    step_view: ProofStepView
+
+    def __init__(self, graph_view: GraphView, x: float, y: float, vty: VertexType, step_view: ProofStepView) -> None:
+        super().__init__(graph_view, x, y, vty)
+        self.step_view = step_view
+        self.proof_step_index = int(step_view.currentIndex().row())
+
+    def undo(self) -> None:
+        self.step_view.move_to_step(self.proof_step_index)
+        super().undo()
+        self.step_view.model().set_graph(self.proof_step_index, self.graph_view.graph_scene.g)
+
+    def redo(self) -> None:
+        self.step_view.move_to_step(self.proof_step_index)
+        super().redo()
+        self.step_view.model().set_graph(self.proof_step_index, self.graph_view.graph_scene.g)
+
 @dataclass
 class AddNodeSnapped(BaseCommand):
     """Adds a new spider positioned on an edge, replacing the original edge"""
@@ -288,6 +308,26 @@ class AddEdge(BaseCommand):
     def redo(self) -> None:
         self.g.add_edge((self.u, self.v), self.ety)
         self.update_graph_view()
+
+
+@dataclass
+class AddEdgeProofMode(AddEdge):
+    step_view: ProofStepView
+
+    def __init__(self, graph_view: GraphView, u: VT, v: VT, ety: EdgeType, step_view: ProofStepView) -> None:
+        super().__init__(graph_view, u, v, ety)
+        self.step_view = step_view
+        self.proof_step_index = int(step_view.currentIndex().row())
+
+    def undo(self) -> None:
+        self.step_view.move_to_step(self.proof_step_index)
+        super().undo()
+        self.step_view.model().set_graph(self.proof_step_index, self.graph_view.graph_scene.g)
+
+    def redo(self) -> None:
+        self.step_view.move_to_step(self.proof_step_index)
+        super().redo()
+        self.step_view.model().set_graph(self.proof_step_index, self.graph_view.graph_scene.g)
 
 @dataclass
 class AddEdges(BaseCommand):

--- a/zxlive/dialogs.py
+++ b/zxlive/dialogs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Optional
@@ -9,8 +10,9 @@ from PySide6.QtWidgets import (QDialog, QDialogButtonBox, QFileDialog,
                                QFormLayout, QLineEdit, QMessageBox,
                                QPushButton, QTextEdit, QWidget, QInputDialog)
 from pyzx import Circuit, extract_circuit
+from pyzx.utils import VertexType
 
-from .common import GraphT
+from .common import GraphT, VT
 from .custom_rule import CustomRule, check_rule
 from .proof import ProofModel
 
@@ -334,3 +336,18 @@ def create_new_rewrite(parent: MainWindow) -> None:
     button_box.accepted.connect(add_rewrite)
     button_box.rejected.connect(dialog.reject)
     if not dialog.exec(): return
+
+def update_dummy_vertex_text(parent: QWidget, graph: GraphT, v: VT) -> Optional[GraphT]:
+    """Prompt the user for text and return a new graph with the text stored in the vertex's vdata under key 'text'.
+    If the user cancels, return None. Otherwise, return the new graph with the updated vdata.
+    """
+    if graph.type(v) != VertexType.DUMMY:
+        show_error_msg("Invalid Vertex Type", "This function can only be used on dummy vertices.", parent=parent)
+        return None
+    current_text = graph.vdata(v, 'text', '')
+    input_, ok = QInputDialog.getText(parent, "Set Text", "Enter text for dummy node:", text=current_text)
+    if not ok:
+        return None
+    new_g = copy.deepcopy(graph)
+    new_g.set_vdata(v, 'text', input_)
+    return new_g

--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -192,6 +192,10 @@ class EditorBasePanel(BasePanel):
         if graph.type(u) == VertexType.W_INPUT and len(graph.neighbors(u)) >= 2 or \
             graph.type(v) == VertexType.W_INPUT and len(graph.neighbors(v)) >= 2:
             return None
+        if (graph.type(u) == VertexType.DUMMY and graph.type(v) != VertexType.DUMMY) or \
+              (graph.type(u) != VertexType.DUMMY and graph.type(v) == VertexType.DUMMY):
+            return None
+
         # We will try to connect all the vertices together in order
         # First we filter out the vertices that are not compatible with the edge.
         verts = [vitem for vitem in verts if not graph.type(vitem.v) == VertexType.W_INPUT] # we will be adding two edges, which is not compatible with W_INPUT

--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -236,7 +236,8 @@ class EditorBasePanel(BasePanel):
             return None
         if graph.type(v) == VertexType.DUMMY:
             # Prompt for text and store in vdata
-            input_, ok = QInputDialog.getText(self, "Set Text", "Enter text for dummy node:")
+            current_text = graph.vdata(v, 'text', '')
+            input_, ok = QInputDialog.getText(self, "Set Text", "Enter text for dummy node:", text=current_text)
             if not ok:
                 return None
             # Store in vdata under key 'text'

--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -50,7 +50,7 @@ def vertices_data() -> dict[VertexType, DrawPanelNodeType]:
         VertexType.Z_BOX: {"text": "Z box", "icon": (ShapeType.SQUARE, display_setting.effective_colors["z_spider"])},
         VertexType.W_OUTPUT: {"text": "W node", "icon": (ShapeType.TRIANGLE, display_setting.effective_colors["w_output"])},
         VertexType.BOUNDARY: {"text": "boundary", "icon": (ShapeType.CIRCLE, display_setting.effective_colors["w_input"])},
-        VertexType.DUMMY: {"text": "Blank", "icon": (ShapeType.CIRCLE, display_setting.effective_colors["dummy"])},
+        VertexType.DUMMY: {"text": "Dummy", "icon": (ShapeType.CIRCLE, display_setting.effective_colors["dummy"])},
     }
 
 def edges_data() -> dict[EdgeType, DrawPanelNodeType]:

--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -128,7 +128,6 @@ class EditorBasePanel(BasePanel):
             self.undo_stack.push(cmd)
 
     def paste_graph(self, graph: GraphT) -> None:
-        if graph is None: return
         new_g = copy.deepcopy(self.graph_scene.g)
         new_verts, new_edges = new_g.merge(graph.translate(0.5, 0.5))
         cmd = UpdateGraph(self.graph_view,new_g)

--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -50,7 +50,7 @@ def vertices_data() -> dict[VertexType, DrawPanelNodeType]:
         VertexType.Z_BOX: {"text": "Z box", "icon": (ShapeType.SQUARE, display_setting.effective_colors["z_spider"])},
         VertexType.W_OUTPUT: {"text": "W node", "icon": (ShapeType.TRIANGLE, display_setting.effective_colors["w_output"])},
         VertexType.BOUNDARY: {"text": "boundary", "icon": (ShapeType.CIRCLE, display_setting.effective_colors["w_input"])},
-        VertexType.DUMMY: {"text": "dummy (blank)", "icon": (ShapeType.CIRCLE, QColor("#ff69b4"))},
+        VertexType.DUMMY: {"text": "Blank", "icon": (ShapeType.CIRCLE, display_setting.effective_colors["dummy"])},
     }
 
 def edges_data() -> dict[EdgeType, DrawPanelNodeType]:

--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -50,6 +50,7 @@ def vertices_data() -> dict[VertexType, DrawPanelNodeType]:
         VertexType.Z_BOX: {"text": "Z box", "icon": (ShapeType.SQUARE, display_setting.effective_colors["z_spider"])},
         VertexType.W_OUTPUT: {"text": "W node", "icon": (ShapeType.TRIANGLE, display_setting.effective_colors["w_output"])},
         VertexType.BOUNDARY: {"text": "boundary", "icon": (ShapeType.CIRCLE, display_setting.effective_colors["w_input"])},
+        VertexType.DUMMY: {"text": "dummy (blank)", "icon": (ShapeType.CIRCLE, QColor("#ff69b4"))},
     }
 
 def edges_data() -> dict[EdgeType, DrawPanelNodeType]:
@@ -229,7 +230,17 @@ class EditorBasePanel(BasePanel):
         old_variables = graph.variable_types.copy()
         if graph.type(v) == VertexType.BOUNDARY or vertex_is_w(graph.type(v)):
             return None
-
+        if graph.type(v) == VertexType.DUMMY:
+            # Prompt for text and store in vdata
+            input_, ok = QInputDialog.getText(self, "Set Text", "Enter text for dummy node:")
+            if not ok:
+                return None
+            # Store in vdata under key 'text'
+            new_g = copy.deepcopy(self.graph_scene.g)
+            new_g.set_vdata(v, 'text', input_)
+            cmd = SetGraph(self.graph_view, new_g)
+            self.undo_stack.push(cmd)
+            return
         phase_is_complex = (graph.type(v) == VertexType.Z_BOX)
         if phase_is_complex:
             prompt = "Enter desired phase value (complex value):"

--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -236,8 +236,7 @@ class EditorBasePanel(BasePanel):
         if graph.type(v) == VertexType.DUMMY:
             new_g = update_dummy_vertex_text(self, self.graph_scene.g, v)
             if new_g is not None:
-                cmd = SetGraph(self.graph_view, new_g)
-                self.undo_stack.push(cmd)
+                self.undo_stack.push(SetGraph(self.graph_view, new_g))
             return
         phase_is_complex = (graph.type(v) == VertexType.Z_BOX)
         if phase_is_complex:
@@ -258,8 +257,7 @@ class EditorBasePanel(BasePanel):
         except ValueError:
             show_error_msg("Invalid Input", error_msg, parent=self)
             return None
-        cmd = ChangePhase(self.graph_view, v, new_phase)
-        self.undo_stack.push(cmd)
+        self.undo_stack.push(ChangePhase(self.graph_view, v, new_phase))
         # For some reason it is important we first push to the stack before we do the following.
         if len(graph.variable_types) != len(old_variables):
             new_vars = graph.variable_types.keys() - old_variables.keys()

--- a/zxlive/editor_base_panel.py
+++ b/zxlive/editor_base_panel.py
@@ -21,7 +21,7 @@ from .commands import (BaseCommand, AddEdge, AddEdges, AddNode, AddNodeSnapped, 
                        ChangeNodeType, ChangePhase, MoveNode, SetGraph,
                        UpdateGraph)
 from .common import VT, GraphT, ToolType, get_data
-from .dialogs import show_error_msg
+from .dialogs import show_error_msg, update_dummy_vertex_text
 from .eitem import EItem, HAD_EDGE_BLUE, EItemAnimation
 from .vitem import VItem, BLACK, VItemAnimation
 from .graphscene import EditGraphScene
@@ -234,16 +234,10 @@ class EditorBasePanel(BasePanel):
         if graph.type(v) == VertexType.BOUNDARY or vertex_is_w(graph.type(v)):
             return None
         if graph.type(v) == VertexType.DUMMY:
-            # Prompt for text and store in vdata
-            current_text = graph.vdata(v, 'text', '')
-            input_, ok = QInputDialog.getText(self, "Set Text", "Enter text for dummy node:", text=current_text)
-            if not ok:
-                return None
-            # Store in vdata under key 'text'
-            new_g = copy.deepcopy(self.graph_scene.g)
-            new_g.set_vdata(v, 'text', input_)
-            cmd = SetGraph(self.graph_view, new_g)
-            self.undo_stack.push(cmd)
+            new_g = update_dummy_vertex_text(self, self.graph_scene.g, v)
+            if new_g is not None:
+                cmd = SetGraph(self.graph_view, new_g)
+                self.undo_stack.push(cmd)
             return
         phase_is_complex = (graph.type(v) == VertexType.Z_BOX)
         if phase_is_complex:

--- a/zxlive/eitem.py
+++ b/zxlive/eitem.py
@@ -23,7 +23,7 @@ from PySide6.QtWidgets import QGraphicsEllipseItem, QGraphicsPathItem, QGraphics
     QGraphicsSceneMouseEvent, QStyleOptionGraphicsItem, QWidget, QStyle
 from PySide6.QtGui import QPen, QPainter, QColor, QPainterPath, QPainterPathStroker
 
-from pyzx.utils import EdgeType
+from pyzx.utils import EdgeType, VertexType
 
 from .common import SCALE, ET, GraphT
 from .vitem import VItem, EITEM_Z
@@ -93,7 +93,11 @@ class EItem(QGraphicsPathItem):
             pen.setDashPattern([4.0, 2.0])
         else:
             from .settings import display_setting
-            pen.setColor(display_setting.effective_colors["edge"])
+            if self.g.type(self.g.edge_s(self.e)) == VertexType.DUMMY or \
+               self.g.type(self.g.edge_t(self.e)) == VertexType.DUMMY:
+                pen.setColor(display_setting.effective_colors["dummy_edge"])
+            else:
+                pen.setColor(display_setting.effective_colors["edge"])
         self.setPen(QPen(pen))
 
         if not self.is_dragging:

--- a/zxlive/mainwindow.py
+++ b/zxlive/mainwindow.py
@@ -444,10 +444,9 @@ class MainWindow(QMainWindow):
 
     def cut_graph(self) -> None:
         assert self.active_panel is not None
-        if isinstance(self.active_panel, GraphEditPanel) or isinstance(self.active_panel, RulePanel):
-            self.copied_graph = self.active_panel.copy_selection()
-            self.paste_action.setEnabled(True)
-            self.active_panel.delete_selection()
+        self.copied_graph = self.active_panel.copy_selection()
+        self.paste_action.setEnabled(True)
+        self.active_panel.delete_selection()
 
     def copy_graph(self) -> None:
         assert self.active_panel is not None
@@ -463,22 +462,19 @@ class MainWindow(QMainWindow):
 
     def paste_graph(self) -> None:
         assert self.active_panel is not None
-        if (isinstance(self.active_panel, GraphEditPanel) or isinstance(self.active_panel, RulePanel)) \
-            and self.copied_graph is not None:
+        if self.copied_graph is not None:
             self.active_panel.paste_graph(self.copied_graph)
 
     def paste_graph_from_clipboard(self) -> None:
         assert self.active_panel is not None
-        if isinstance(self.active_panel, GraphEditPanel) or isinstance(self.active_panel, RulePanel): 
-            tikz = pyperclip.paste()
-            copied_graph = from_tikz(tikz)
-            if copied_graph is not None:
-                self.active_panel.paste_graph(copied_graph)
+        tikz = pyperclip.paste()
+        copied_graph = from_tikz(tikz)
+        if copied_graph is not None:
+            self.active_panel.paste_graph(copied_graph)
 
     def delete_graph(self) -> None:
         assert self.active_panel is not None
-        if isinstance(self.active_panel, GraphEditPanel) or isinstance(self.active_panel, RulePanel):
-            self.active_panel.delete_selection()
+        self.active_panel.delete_selection()
 
     def _new_panel(self, panel: BasePanel, name: str) -> None:
         self.tab_widget.addTab(panel, name)

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -16,7 +16,7 @@ from pyzx.utils import (EdgeType, VertexType, FractionLike, get_w_partner, get_z
 
 from . import animations as anims
 from .base_panel import BasePanel, ToolbarSection
-from .commands import AddRewriteStep, ChangeEdgeCurveProofMode, MoveNodeProofMode, SetGraph, UpdateGraph
+from .commands import AddRewriteStep, ChangeEdgeCurveProofMode, MoveNodeProofMode, SetGraphProofMode, UpdateGraphProofMode
 from .common import ET, VT, GraphT, ToolType, get_data, pos_from_view, pos_to_view
 from .dialogs import show_error_msg
 from .editor_base_panel import string_to_complex
@@ -508,8 +508,8 @@ class ProofPanel(BasePanel):
         new_g = copy.deepcopy(self.graph_scene.g)
         new_g.remove_edges(rem_edges)
         new_g.remove_vertices(list(set(rem_vertices)))
-        cmd = SetGraph(self.graph_view,new_g) if len(set(rem_vertices)) > 128 \
-            else UpdateGraph(self.graph_view,new_g)
+        cmd = SetGraphProofMode(self.graph_view, new_g, self.step_view) if len(set(rem_vertices)) > 128 \
+            else UpdateGraphProofMode(self.graph_view, new_g, self.step_view)
         self.undo_stack.push(cmd)
 
     def paste_graph(self, graph: GraphT) -> None:
@@ -519,6 +519,6 @@ class ProofPanel(BasePanel):
         dummy_graph = graph.subgraph_from_vertices(dummy_vertices)
         new_g = copy.deepcopy(self.graph_scene.g)
         new_verts, new_edges = new_g.merge(dummy_graph.translate(0.5, 0.5))
-        cmd = UpdateGraph(self.graph_view, new_g)
+        cmd = UpdateGraphProofMode(self.graph_view, new_g, self.step_view)
         self.undo_stack.push(cmd)
         self.graph_scene.select_vertices(new_verts)

--- a/zxlive/proof_panel.py
+++ b/zxlive/proof_panel.py
@@ -18,7 +18,7 @@ from . import animations as anims
 from .base_panel import BasePanel, ToolbarSection
 from .commands import AddRewriteStep, ChangeEdgeCurveProofMode, MoveNodeProofMode, SetGraphProofMode, UpdateGraphProofMode
 from .common import ET, VT, GraphT, ToolType, get_data, pos_from_view, pos_to_view
-from .dialogs import show_error_msg
+from .dialogs import show_error_msg, update_dummy_vertex_text
 from .editor_base_panel import string_to_complex
 from .eitem import EItem
 from .graphscene import EditGraphScene
@@ -457,11 +457,17 @@ class ProofPanel(BasePanel):
             return
         if ty == VertexType.H_BOX:
             new_g = copy.deepcopy(self.graph)
-            if not pyzx.hrules.is_hadamard(new_g, v): 
+            if not pyzx.hrules.is_hadamard(new_g, v):
                 return
             pyzx.hrules.replace_hadamard(new_g, v)
             cmd = AddRewriteStep(self.graph_view, new_g, self.step_view, "Turn Hadamard into edge")
             self.undo_stack.push(cmd)
+            return
+        if ty == VertexType.DUMMY:
+            new_graph = update_dummy_vertex_text(self, self.graph, v)
+            if new_graph is not None:
+                cmd_dummy = SetGraphProofMode(self.graph_view, new_graph, self.step_view)
+                self.undo_stack.push(cmd_dummy)
             return
 
     def _edge_double_clicked(self, e: ET) -> None:

--- a/zxlive/rewrite_action.py
+++ b/zxlive/rewrite_action.py
@@ -6,6 +6,7 @@ from typing import Callable, TYPE_CHECKING, Any, cast, Union, Optional
 from concurrent.futures import ThreadPoolExecutor
 
 import pyzx
+from pyzx.utils import VertexType
 
 from PySide6.QtCore import (Qt, QAbstractItemModel, QModelIndex, QPersistentModelIndex,
                             Signal, QObject, QMetaObject, QIODevice, QBuffer, QPoint, QPointF, QLineF)
@@ -78,9 +79,20 @@ class RewriteAction:
         rem_verts_list: list[VT] = []
         matches_list: list[VT | ET] = []
         while True:
-            matches = self.matcher(g, lambda v: v in verts) \
-                      if self.match_type == MATCHES_VERTICES \
-                      else self.matcher(g, lambda e: e in edges)
+            if self.match_type == MATCHES_VERTICES:
+                matches = self.matcher(
+                    g,
+                    lambda v: v in verts and g.type(v) != VertexType.DUMMY
+                )
+            else:
+                matches = self.matcher(
+                    g,
+                    lambda e: (
+                        e in edges and
+                        g.type(g.edge_s(e)) != VertexType.DUMMY and
+                        g.type(g.edge_t(e)) != VertexType.DUMMY
+                    )
+                )
             matches_list.extend(matches)
             if not matches:
                 break

--- a/zxlive/settings.py
+++ b/zxlive/settings.py
@@ -114,9 +114,10 @@ modern_red_green: ColorScheme = {
     "w_output": QColor("#000000"),
     "w_output_pressed": QColor("#444444"),
     "outline": QColor("#000000"),
-    "edge": QColor("#000000"),
     "dummy": QColor("#B6B6B6"),
     "dummy_pressed": QColor("#808080"),
+    "edge": QColor("#000000"),
+    "dummy_edge": QColor("#808080"),
 }
 
 classic_red_green: ColorScheme = {

--- a/zxlive/settings.py
+++ b/zxlive/settings.py
@@ -61,6 +61,7 @@ tikz_export_defaults: dict[str, str] = {
     "tikz/Hadamard-export": pyzx.settings.tikz_classes['H'],
     "tikz/w-output-export": pyzx.settings.tikz_classes['W'],
     "tikz/w-input-export": pyzx.settings.tikz_classes['W input'],
+    "tikz/dummy-export": pyzx.settings.tikz_classes['dummy'],
     "tikz/edge-export": pyzx.settings.tikz_classes['edge'],
     "tikz/edge-H-export": pyzx.settings.tikz_classes['H-edge'],
     "tikz/edge-W-export": pyzx.settings.tikz_classes['W-io-edge'],
@@ -74,6 +75,7 @@ tikz_import_defaults: dict[str, str] = {
     "tikz/w-input-import": ", ".join(pyzx.tikz.synonyms_w_input),
     "tikz/w-output-import": ", ".join(pyzx.tikz.synonyms_w_output),
     "tikz/z-box-import": ", ".join(pyzx.tikz.synonyms_z_box),
+    "tikz/dummy-import": ", ".join(pyzx.tikz.synonyms_dummy),
     "tikz/edge-import": ", ".join(pyzx.tikz.synonyms_edge),
     "tikz/edge-H-import": ", ".join(pyzx.tikz.synonyms_hedge),
     "tikz/edge-W-import": ", ".join(pyzx.tikz.synonyms_wedge),
@@ -173,6 +175,7 @@ def load_tikz_classes() -> dict[str, str]:
         'H': str(settings.value('tikz/Hadamard-export', pyzx.settings.tikz_classes['H'])),
         'W': str(settings.value('tikz/W-output-export', pyzx.settings.tikz_classes['W'])),
         'W input': str(settings.value('tikz/W-input-export', pyzx.settings.tikz_classes['W input'])),
+        'dummy': str(settings.value('tikz/dummy-export', pyzx.settings.tikz_classes['dummy'])),
         'edge': str(settings.value('tikz/edge-export', pyzx.settings.tikz_classes['edge'])),
         'H-edge': str(settings.value('tikz/edge-H-export', pyzx.settings.tikz_classes['H-edge'])),
         'W-io-edge': str(settings.value('tikz/edge-W-export', pyzx.settings.tikz_classes['W-io-edge'])),
@@ -194,6 +197,7 @@ def refresh_pyzx_tikz_settings() -> None:
     pyzx.tikz.synonyms_w_input = _get_synonyms('tikz/W-input-import', pyzx.tikz.synonyms_w_input)
     pyzx.tikz.synonyms_w_output = _get_synonyms('tikz/W-output-import', pyzx.tikz.synonyms_w_output)
     pyzx.tikz.synonyms_z_box = _get_synonyms('tikz/Z-box-import', pyzx.tikz.synonyms_z_box)
+    pyzx.tikz.synonyms_dummy = _get_synonyms('tikz/dummy-import', pyzx.tikz.synonyms_dummy)
     pyzx.tikz.synonyms_edge = _get_synonyms('tikz/edge-import', pyzx.tikz.synonyms_edge)
     pyzx.tikz.synonyms_hedge = _get_synonyms('tikz/edge-H-import', pyzx.tikz.synonyms_hedge)
     pyzx.tikz.synonyms_wedge = _get_synonyms('tikz/edge-W-import', pyzx.tikz.synonyms_wedge)

--- a/zxlive/settings.py
+++ b/zxlive/settings.py
@@ -26,7 +26,10 @@ class ColorScheme(TypedDict):
     w_output: QColor
     w_output_pressed: QColor
     outline: QColor
+    dummy: QColor
+    dummy_pressed: QColor
     edge: QColor
+    dummy_edge: QColor
 
 
 general_defaults: dict[str, str | QTabWidget.TabPosition | int | bool] = {

--- a/zxlive/settings.py
+++ b/zxlive/settings.py
@@ -115,6 +115,8 @@ modern_red_green: ColorScheme = {
     "w_output_pressed": QColor("#444444"),
     "outline": QColor("#000000"),
     "edge": QColor("#000000"),
+    "dummy": QColor("#B6B6B6"),
+    "dummy_pressed": QColor("#808080"),
 }
 
 classic_red_green: ColorScheme = {

--- a/zxlive/settings_dialog.py
+++ b/zxlive/settings_dialog.py
@@ -109,6 +109,7 @@ tikz_export_settings: list[SettingsData] = [
     {"id": "tikz/w-input-export", "label": "W input", "type": FormInputType.Str},
     {"id": "tikz/w-output-export", "label": "W output", "type": FormInputType.Str},
     {"id": "tikz/z-box-export", "label": "Z box", "type": FormInputType.Str},
+    {"id": "tikz/dummy-export", "label": "Dummy node", "type": FormInputType.Str},
     {"id": "tikz/edge-W-export", "label": "W io edge", "type": FormInputType.Str},
 ]
 
@@ -119,6 +120,7 @@ tikz_import_settings: list[SettingsData] = [
     {"id": "tikz/w-input-import", "label": "W input", "type": FormInputType.Str},
     {"id": "tikz/w-output-import", "label": "W output", "type": FormInputType.Str},
     {"id": "tikz/z-box-import", "label": "Z box", "type": FormInputType.Str},
+    {"id": "tikz/dummy-import", "label": "Dummy node", "type": FormInputType.Str},
     {"id": "tikz/edge-import", "label": "regular edge", "type": FormInputType.Str},
     {"id": "tikz/edge-H-import", "label": "H edge", "type": FormInputType.Str},
     {"id": "tikz/edge-W-import", "label": "W io edge", "type": FormInputType.Str},

--- a/zxlive/vitem.py
+++ b/zxlive/vitem.py
@@ -201,10 +201,7 @@ class VItem(QGraphicsPathItem):
             path.lineTo(0.25 * SCALE, -0.15 * SCALE)
             path.lineTo(-0.25 * SCALE, -0.15 * SCALE)
             path.closeSubpath()
-        elif self.ty == VertexType.W_INPUT or self.ty == VertexType.BOUNDARY:
-            scale = 0.3 * SCALE
-            path.addEllipse(-0.2 * scale, -0.2 * scale, 0.4 * scale, 0.4 * scale)
-        elif self.ty == VertexType.DUMMY:
+        elif self.ty in {VertexType.W_INPUT, VertexType.BOUNDARY, VertexType.DUMMY}:
             scale = 0.3 * SCALE
             path.addEllipse(-0.2 * scale, -0.2 * scale, 0.4 * scale, 0.4 * scale)
         else:

--- a/zxlive/vitem.py
+++ b/zxlive/vitem.py
@@ -145,26 +145,23 @@ class VItem(QGraphicsPathItem):
         pen = QPen()
         if not self.isSelected():
             color_key = color_map.get(self.ty, "boundary")
-            if color_key == "dummy":
-                brush = QBrush(QColor("#ff69b4"))  # Pink for dummy
-            else:
-                brush = QBrush(display_setting.effective_colors[color_key])
+            brush = QBrush(display_setting.effective_colors[color_key]) # type: ignore # https://github.com/python/mypy/issues/7178
             pen.setWidthF(3)
             pen.setColor(display_setting.effective_colors["outline"])
+            if self.ty == VertexType.DUMMY:
+                pen.setColor(display_setting.effective_colors["dummy"])
         else:
             color_key = pressed_color_map.get(self.ty, "boundary_pressed")
-            if color_key == "dummy_pressed":
-                brush = QBrush(QColor("#ffb6d5"))  # Lighter pink for pressed dummy
-                brush.setStyle(Qt.BrushStyle.Dense1Pattern)
-            else:
-                brush = QBrush(display_setting.effective_colors[color_key])
-                brush.setStyle(Qt.BrushStyle.Dense1Pattern)
+            brush = QBrush(display_setting.effective_colors[color_key]) # type: ignore # https://github.com/python/mypy/issues/7178
+            brush.setStyle(Qt.BrushStyle.Dense1Pattern)
             pen.setWidthF(5)
             # Use a light outline in dark mode, otherwise use the pressed color
             if display_setting.dark_mode:
                 pen.setColor(QColor("#dbdbdb"))
             else:
                 pen.setColor(display_setting.effective_colors["boundary_pressed"])
+            if self.ty == VertexType.DUMMY:
+                pen.setColor(display_setting.effective_colors["dummy_pressed"])
         self.prepareGeometryChange()
         self.setBrush(brush)
         self.setPen(pen)
@@ -175,13 +172,11 @@ class VItem(QGraphicsPathItem):
             if self.dummy_text_item is None:
                 self.dummy_text_item = QGraphicsTextItem(self)
                 self.dummy_text_item.setDefaultTextColor(QColor("#222"))
-                font = display_setting.font
-                font.setPointSizeF(font.pointSizeF() * 0.9)
-                self.dummy_text_item.setFont(font)
+                self.dummy_text_item.setFont(display_setting.font)
             self.dummy_text_item.setPlainText(text)
             # Center the text in the node
             rect = self.dummy_text_item.boundingRect()
-            self.dummy_text_item.setPos(-rect.width()/2, -rect.height()/2)
+            self.dummy_text_item.setPos(-rect.width()/2, -rect.height()/2 - 0.25 * SCALE)
             self.dummy_text_item.setVisible(bool(text))
         elif self.dummy_text_item is not None:
             self.dummy_text_item.setVisible(False)
@@ -210,7 +205,8 @@ class VItem(QGraphicsPathItem):
             scale = 0.3 * SCALE
             path.addEllipse(-0.2 * scale, -0.2 * scale, 0.4 * scale, 0.4 * scale)
         elif self.ty == VertexType.DUMMY:
-            path.addEllipse(-0.2 * SCALE, -0.2 * SCALE, 0.4 * SCALE, 0.4 * SCALE)
+            scale = 0.3 * SCALE
+            path.addEllipse(-0.2 * scale, -0.2 * scale, 0.4 * scale, 0.4 * scale)
         else:
             path.addEllipse(-0.2 * SCALE, -0.2 * SCALE, 0.4 * SCALE, 0.4 * SCALE)
         return path


### PR DESCRIPTION
Implements #268
Requires the dummy node implementation from this pyzx PR https://github.com/zxcalc/pyzx/pull/320 

I have added a new node type called dummy which we can use to add textual annotations. We can also use these nodes to draw shapes that don't have semantic meaning but are useful for clarity. 

I have not added support for maths/latex yet. I think it would be better to add latex support in a separate PR.

I would appreciate more feedback on this before we merge it.