### PR TITLE
Avoid removing eitem twice from self-loop

### DIFF
--- a/zxlive/graphscene.py
+++ b/zxlive/graphscene.py
@@ -134,7 +134,8 @@ class GraphScene(QGraphicsScene):
             for anim_e in e_item.active_animations.copy():
                 anim_e.stop()
             e_item.s_item.adj_items.remove(e_item)
-            e_item.t_item.adj_items.remove(e_item)
+            if e_item.s_item != e_item.t_item:
+                e_item.t_item.adj_items.remove(e_item)
             self.removeItem(e_item)
             self.edge_map[e].pop(edge_idx)
             s, t = self.g.edge_st(e)


### PR DESCRIPTION
Reproducing the bug:
<img width="402" height="260" alt="image" src="https://github.com/user-attachments/assets/35af28b2-80ae-49ce-8b81-7f31df55fd92" />

Fuse the spiders with the parallel edges, then drag the Hadamard self-loop. Some of the edges will disappear and we get the following error:
<img width="421" height="262" alt="image" src="https://github.com/user-attachments/assets/8607d6da-e7a0-4f5f-8c16-604d1c952aa4" />


```
  File "zxlive/zxlive/graphview.py", line 121, in update_graph
    self.graph_scene.update_graph(g, select_new)
  File "zxlive/zxlive/graphscene.py", line 137, in update_graph
    e_item.t_item.adj_items.remove(e_item)
KeyError: <zxlive.eitem.EItem(0x600003406900, pos=0,0, z=-1, flags=(ItemIsSelectable|ItemSendsGeometryChanges)) at 0x10a44a080>
```

The issue is `GraphScene.update_graph()` removes eitem twice when the source and target are the same:
```python
e_item.s_item.adj_items.remove(e_item)
e_item.t_item.adj_items.remove(e_item)
```
